### PR TITLE
Replace mikkyang/id3-go with a module already required

### DIFF
--- a/service/podcastService.go
+++ b/service/podcastService.go
@@ -19,7 +19,7 @@ import (
 	"github.com/akhilrex/podgrab/internal/sanitize"
 	"github.com/antchfx/xmlquery"
 	strip "github.com/grokify/html-strip-tags-go"
-	id3 "github.com/mikkyang/id3-go"
+	id3 "github.com/arkhipovkm/id3-go"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )


### PR DESCRIPTION
Hi.

I had trouble getting podgrab to build.  It failed with this message:

```
#19 1.153 service/podcastService.go:22:2: no required module provides package github.com/mikkyang/id3-go; to add it:
#19 1.153 	go get github.com/mikkyang/id3-go
```

While having never written a line of Go, I had a crack at fixing this and this PR is the result.

Cheers.
Shaun.